### PR TITLE
Allow friends & yourself to see your actual username & skin while nicked

### DIFF
--- a/core/src/main/java/tc/oc/pgm/listeners/SkinCache.java
+++ b/core/src/main/java/tc/oc/pgm/listeners/SkinCache.java
@@ -104,11 +104,15 @@ public class SkinCache implements Listener {
   // TODO: Figure out how to use without SPORTPAPER API
   public void refreshFakeName(Player player, Player viewer) {
     boolean nicked = Integration.getNick(player) != null;
+    boolean areFriends = Integration.isFriend(player, viewer);
     boolean isViewerStaff = viewer.hasPermission(Permissions.STAFF);
     boolean isViewerAdmin = viewer.hasPermission(Permissions.ADMIN);
     boolean override = player.hasPermission(Permissions.ADMIN);
 
-    if (nicked && (!isViewerStaff || (override && !isViewerAdmin))) {
+    boolean canSeeRealName =
+        override ? isViewerAdmin : (isViewerStaff || player == viewer || areFriends);
+
+    if (nicked && !canSeeRealName) {
       String nick = Integration.getNick(player);
       MatchPlayer matchPlayer = PGM.get().getMatchManager().getPlayer(player);
       String displayName =


### PR DESCRIPTION
Fixes seeing your username as white. However, it does not fix the bug where players after joining will sometimes see nicked players with a white username overhead, as supposed to their nickname in team colours overhead.

Before:
![image](https://user-images.githubusercontent.com/9807038/130265951-947eb616-94ff-4d6a-aa20-adfffdce839d.png)

After:
![image](https://user-images.githubusercontent.com/9807038/130265915-83433583-3746-490c-8238-b1ce8791c2f3.png)

